### PR TITLE
Ruby 2.4 support: fix for deprecated Fixnum

### DIFF
--- a/config/initializers/will_paginate.rb
+++ b/config/initializers/will_paginate.rb
@@ -21,7 +21,7 @@ module WillPaginate
       def to_html
         list_items = pagination.map do |item|
           case item
-            when Fixnum
+            when (1.class == Integer ? Integer : Fixnum)
               page_number(item)
             else
               send(item)


### PR DESCRIPTION
Thanks for developing this gem. 

Fixnum is deprecated in Ruby 2.4+. This PR modifies the code a little bit so that on Ruby 2.4+ Integer will be used instead.