### PR TITLE
Updates to support bootstrap flexbox classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,14 @@ pass an option like so:
         justify-content: center;
     }
 
+The following options are available (in addition to the options available in will_paginate):
+
+    :list_classes = ['pagination']    # Array of classes
+    :aria_label = 'Page Navigation'   # The aria label to use in the Nav tag
+
+For example, to place the navigation section to the far right of the page, use this in your view:
+
+    <%= will_paginate @clients, :list_classes => ['pagination','justify-content-end'] %>
 
 Copyright (c) 2016-2017 [Ivan Palamarchuk](https://github.com/delef) released under the MIT license  
 

--- a/config/initializers/will_paginate.rb
+++ b/config/initializers/will_paginate.rb
@@ -10,7 +10,6 @@ module WillPaginate
       options[:renderer] ||= BootstrapLinkRenderer
       options[:list_classes] ||= ['pagination']
       options[:aria_label] ||= 'Page Navigation'
-      options[:inner_window] = 2
 
       super(collection, options)
     end

--- a/config/initializers/will_paginate.rb
+++ b/config/initializers/will_paginate.rb
@@ -8,8 +8,8 @@ module WillPaginate
 
       options = options.symbolize_keys
       options[:renderer] ||= BootstrapLinkRenderer
-      options[:previous_label] = '&laquo;'
-      options[:next_label] = '&raquo;'
+      options[:list_classes] ||= ['pagination']
+      options[:aria_label] ||= 'Page Navigation'
       options[:inner_window] = 2
 
       super(collection, options)
@@ -28,8 +28,8 @@ module WillPaginate
           end
         end.join(@options[:link_separator])
 
-        list_wrapper = tag :ul, list_items, class: 'pagination', role: 'group'
-        tag :nav, list_wrapper, class: @options[:class]
+        list_wrapper = tag :ul, list_items, class: @options[:list_classes].join(" ").to_s
+        tag :nav, list_wrapper, 'aria-label': @options[:aria_label]
       end
 
       def container_attributes
@@ -54,10 +54,10 @@ module WillPaginate
 
         if page
           link_wrapper = link(text, page, link_options.merge(class: 'page-link'))
-          tag :li, link_wrapper, class: '%s page-item' % classname
+          tag :li, link_wrapper, class: 'page-item'
         else
           span_wrapper = tag(:span, text, class: 'page-link')
-          tag :li, span_wrapper, class: '%s page-item disabled' % classname
+          tag :li, span_wrapper, class: 'page-item disabled'
         end
       end
 

--- a/lib/will_paginate-bootstrap4/version.rb
+++ b/lib/will_paginate-bootstrap4/version.rb
@@ -1,5 +1,5 @@
 module Bootstrap
   module WillPaginate
-    VERSION = '0.1.3'
+    VERSION = '0.1.4'
   end
 end


### PR DESCRIPTION
Remove hardcoding of inner_window, previous_label and  next_label. Add list_classes option (to add additional classes such as justify-content-end) and add an aria_label option to define aria labels for the nav container. 

Clean up tag class names and remove roles to enable bootstrap positioning classes to work correctly

Bumped version / updated README
